### PR TITLE
Improve email service by spliting the providers into different classes

### DIFF
--- a/server/src/__tests__/normal/user.test.tsx
+++ b/server/src/__tests__/normal/user.test.tsx
@@ -1,27 +1,29 @@
+import { Database } from 'better-sqlite3'
+import { Scope } from 'shared'
 import {
   afterEach, beforeEach, describe, expect, Mock, test,
   vi,
 } from 'vitest'
-import { Database } from 'better-sqlite3'
-import { Scope } from 'shared'
-import app from 'index'
 import {
   adapterConfig, localeConfig, routeConfig,
 } from 'configs'
-import {
-  mockedKV,
-  migrate, mock,
-  fetchMock,
-  emailResponseMock,
-  emailLogRecord,
-} from 'tests/mock'
+import app from 'index'
 import {
   userAppConsentModel, userModel,
   userPasskeyModel,
 } from 'models'
 import {
+  emailLogRecord,
+  emailResponseMock,
+  fetchMock,
+  migrate, mock,
+  mockedKV,
+} from 'tests/mock'
+import {
   attachIndividualScopes,
-  dbTime, disableUser, enrollEmailMfa, enrollOtpMfa, getS2sToken, enrollSmsMfa,
+  dbTime, disableUser, enrollEmailMfa, enrollOtpMfa,
+  enrollSmsMfa,
+  getS2sToken,
 } from 'tests/util'
 
 let db: Database

--- a/server/src/configs/locale.ts
+++ b/server/src/configs/locale.ts
@@ -34,7 +34,6 @@ export enum Error {
   WrongTokenType = 'Unsupported token type',
   UniqueKey = 'Unique key constraint failed',
   NoEmailSender = 'No email sender',
-  NoEmailProvider = 'No email provider was found',
   NoSmsSender = 'No sms sender',
 }
 export const common = Object.freeze({

--- a/server/src/configs/locale.ts
+++ b/server/src/configs/locale.ts
@@ -34,6 +34,7 @@ export enum Error {
   WrongTokenType = 'Unsupported token type',
   UniqueKey = 'Unique key constraint failed',
   NoEmailSender = 'No email sender',
+  NoEmailProvider = 'No email provider was found',
   NoSmsSender = 'No sms sender',
 }
 export const common = Object.freeze({

--- a/server/src/services/email/brevo.ts
+++ b/server/src/services/email/brevo.ts
@@ -1,0 +1,43 @@
+import { env } from 'hono/adapter'
+import {
+  IMailer, SendEmailOptions,
+} from './interface'
+
+export class BrevoMailer extends IMailer {
+  async sendEmail ({
+    email, subject, content, senderName,
+  }: SendEmailOptions) {
+    const {
+      BREVO_API_KEY: apiKey, BREVO_SENDER_ADDRESS: sender,
+    } = env(this.context)
+
+    const res = await fetch(
+      'https://api.brevo.com/v3/smtp/email',
+      {
+        method: 'POST',
+        headers: {
+          'api-key': apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          sender: {
+            name: senderName,
+            email: sender,
+          },
+          subject,
+          htmlContent: content,
+          to: [
+            { email },
+          ],
+        }),
+      },
+    )
+
+    return {
+      status: res.status,
+      statusText: res.statusText,
+      url: res.url,
+      body: await res.text(),
+    }
+  }
+}

--- a/server/src/services/email/brevo.ts
+++ b/server/src/services/email/brevo.ts
@@ -33,11 +33,6 @@ export class BrevoMailer extends IMailer {
       },
     )
 
-    return {
-      status: res.status,
-      statusText: res.statusText,
-      url: res.url,
-      body: await res.text(),
-    }
+    return res
   }
 }

--- a/server/src/services/email/interface.ts
+++ b/server/src/services/email/interface.ts
@@ -19,10 +19,5 @@ export abstract class IMailer {
     this.context = opts.context
   }
 
-  abstract sendEmail(options: SendEmailOptions): Promise<{
-    status: number;
-    statusText: string;
-    url: string;
-    body: string;
-  }>
+  abstract sendEmail(options: SendEmailOptions): Promise<any>
 }

--- a/server/src/services/email/interface.ts
+++ b/server/src/services/email/interface.ts
@@ -1,0 +1,28 @@
+import { Context } from 'hono'
+import { typeConfig } from '../../configs'
+
+type BuilderOpts = {
+  context: Context<typeConfig.Context>;
+}
+
+export type SendEmailOptions = {
+  email: string;
+  subject: string;
+  content: string;
+  senderName: string;
+}
+
+export abstract class IMailer {
+  protected context: Context<typeConfig.Context>
+
+  constructor (opts: BuilderOpts) {
+    this.context = opts.context
+  }
+
+  abstract sendEmail(options: SendEmailOptions): Promise<{
+    status: number;
+    statusText: string;
+    url: string;
+    body: string;
+  }>
+}

--- a/server/src/services/email/mailgun.ts
+++ b/server/src/services/email/mailgun.ts
@@ -1,0 +1,52 @@
+import { env } from 'hono/adapter'
+import {
+  IMailer, SendEmailOptions,
+} from './interface'
+
+export class MailgunMailer extends IMailer {
+  async sendEmail ({
+    email, subject, content, senderName,
+  }: SendEmailOptions) {
+    const {
+      MAILGUN_API_KEY: apiKey, MAILGUN_SENDER_ADDRESS: sender,
+    } = env(this.context)
+
+    const form = new FormData()
+    form.append(
+      'from',
+      `${senderName} <${sender}>`,
+    )
+    form.append(
+      'to',
+      email,
+    )
+    form.append(
+      'subject',
+      subject,
+    )
+    form.append(
+      'html',
+      content,
+    )
+
+    const [, domain] = sender.split('@')
+
+    const auth = Buffer.from(`api:${apiKey}`).toString('base64')
+
+    const res = await fetch(
+      `https://api.mailgun.net/v3/${domain}/messages`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Basic ${auth}` },
+        body: form,
+      },
+    )
+
+    return {
+      status: res.status,
+      statusText: res.statusText,
+      url: res.url,
+      body: await res.text(),
+    }
+  }
+}

--- a/server/src/services/email/mailgun.ts
+++ b/server/src/services/email/mailgun.ts
@@ -42,11 +42,6 @@ export class MailgunMailer extends IMailer {
       },
     )
 
-    return {
-      status: res.status,
-      statusText: res.statusText,
-      url: res.url,
-      body: await res.text(),
-    }
+    return res
   }
 }

--- a/server/src/services/email/sendgrid.ts
+++ b/server/src/services/email/sendgrid.ts
@@ -1,0 +1,49 @@
+import { env } from 'hono/adapter'
+import {
+  IMailer, SendEmailOptions,
+} from './interface'
+
+export class SendgridMailer extends IMailer {
+  async sendEmail ({
+    email, subject, content, senderName,
+  }: SendEmailOptions) {
+    const {
+      SENDGRID_API_KEY: apiKey, SENDGRID_SENDER_ADDRESS: sender,
+    } = env(this.context)
+
+    const res = await fetch(
+      'https://api.sendgrid.com/v3/mail/send',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          subject,
+          content: [{
+            type: 'text/html',
+            value: content,
+          }],
+          personalizations: [
+            {
+              to: [
+                { email },
+              ],
+            },
+          ],
+          from: {
+            email: sender, name: senderName,
+          },
+        }),
+      },
+    )
+
+    return {
+      status: res.status,
+      statusText: res.statusText,
+      url: res.url,
+      body: await res.text(),
+    }
+  }
+}

--- a/server/src/services/email/sendgrid.ts
+++ b/server/src/services/email/sendgrid.ts
@@ -39,11 +39,6 @@ export class SendgridMailer extends IMailer {
       },
     )
 
-    return {
-      status: res.status,
-      statusText: res.statusText,
-      url: res.url,
-      body: await res.text(),
-    }
+    return res
   }
 }

--- a/server/src/services/email/smtp.ts
+++ b/server/src/services/email/smtp.ts
@@ -20,10 +20,10 @@ export class SmtpMailer extends IMailer {
     })
 
     return {
-      status: res?.accepted[0] === email ? 200 : 500,
-      statusText: res?.accepted[0] === email ? 'OK' : 'Internal Server Error',
+      status: res?.accepted[0] === email ? 200 : 422,
+      statusText: res?.accepted[0] === email ? 'OK' : 'Unprocessable Entity',
       url: 'smtp://',
-      body: JSON.stringify(res.response),
+      body: JSON.stringify(res),
     }
   }
 }

--- a/server/src/services/email/smtp.ts
+++ b/server/src/services/email/smtp.ts
@@ -19,11 +19,6 @@ export class SmtpMailer extends IMailer {
       html: content,
     })
 
-    return {
-      status: res?.accepted[0] === email ? 200 : 422,
-      statusText: res?.accepted[0] === email ? 'OK' : 'Unprocessable Entity',
-      url: 'smtp://',
-      body: JSON.stringify(res),
-    }
+    return res
   }
 }

--- a/server/src/services/email/smtp.ts
+++ b/server/src/services/email/smtp.ts
@@ -1,0 +1,29 @@
+import { env } from 'hono/adapter'
+import { Transporter } from 'nodemailer'
+import { SentMessageInfo } from 'nodemailer/lib/smtp-transport'
+import {
+  IMailer, SendEmailOptions,
+} from './interface'
+
+export class SmtpMailer extends IMailer {
+  async sendEmail ({
+    email, subject, content, senderName,
+  }: SendEmailOptions) {
+    const { SMTP_SENDER_ADDRESS: sender } = env(this.context)
+
+    const transporter: Transporter<SentMessageInfo> = this.context.env.SMTP.init()
+    const res = await transporter.sendMail({
+      from: `"${senderName}" ${sender}`,
+      to: email,
+      subject,
+      html: content,
+    })
+
+    return {
+      status: res?.accepted[0] === email ? 200 : 500,
+      statusText: res?.accepted[0] === email ? 'OK' : 'Internal Server Error',
+      url: 'smtp://',
+      body: JSON.stringify(res.response),
+    }
+  }
+}


### PR DESCRIPTION
First, just wanted to say that I really like the project and the work you've done so far!

This PR is mostly a minor improvement on how we are capturing the email provider information -- main reason because i wanted to add https://resend.com/ but didn't want to make the if block larger than it is.

This PR:

- Creates an abstract class that mailers can extend. Main reason to do it this way is to ensure consistent typings/returns and hide those details on each mailer that implements it
- Creates a mailer class for each, that way we can isolate any future nuances and eventually add more providers (e.g. resend, in another PR) 👌🏽 


Feel free to discard or take over the PR if you don't like the approach of classes, I'm not married to it.