### PR TITLE
Add resend.com to supported mail providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
   - SendGrid
   - Mailgun
   - Brevo
+  - Resend
   - STMP (Node.js environment only)
 - <b>SMS Option</b> [SMS Provider Setup Doc](https://auth.valuemelody.com/sms-provider-setup.html)
   - Twilio
@@ -93,8 +94,8 @@
 - [React Native Example](https://github.com/ValueMelody/melody-auth/tree/main/examples/react-native-example)
 
 ## Screenshots
-[Authorization Screenshots](https://auth.valuemelody.com/screenshots.html#identity-pages-and-emails)  
-[Admin Panel Screenshots](https://auth.valuemelody.com/screenshots.html#admin-panel-pages)  
+[Authorization Screenshots](https://auth.valuemelody.com/screenshots.html#identity-pages-and-emails)
+[Admin Panel Screenshots](https://auth.valuemelody.com/screenshots.html#admin-panel-pages)
 
 ## License
 

--- a/docs/email-provider-setup.md
+++ b/docs/email-provider-setup.md
@@ -18,6 +18,8 @@ Use the table below to configure your chosen email provider. Some variables are 
 | MAILGUN_SENDER_ADDRESS | Sender email address in Mailgun (Required if you intend to use Mailgun) | "noreply@yourdomain.com" |
 | BREVO_API_KEY | Your Brevo API key (Required if you intend to use Brevo) | "xkeysib-xxxxxxxxxxxxxxxxxxxxxxxx" |
 | BREVO_SENDER_ADDRESS | Verified sender address in Brevo (Required if you intend to use Brevo) | "noreply@yourdomain.com" |
+| RESEND_API_KEY | Your Resend.io API key (Required if you intend to use Resend.io) | "re_xxxxxxxxxxxxxxxxxxxxxxx" |
+| RESEND_SENDER_ADDRESS | Verified sender address in Resend.com (Required if you intend to use Resend.com) |
 | SMTP_SENDER_ADDRESS | SMTP sender email address (Node.js only) | "noreply@yourdomain.com" |
 | SMTP_CONNECTION_STRING | SMTP connection string (Node.js only) | "smtp://username:password@smtp.mailserver.com:587" |
 

--- a/docs/email-provider-setup.md
+++ b/docs/email-provider-setup.md
@@ -2,7 +2,7 @@
 Melody Auth relies on an email provider to send password reset links, email verification notices, and email-based MFA codes. This guide explains how to configure either SendGrid, Mailgun, Brevo, or SMTP (Node.js only) depending on your needs.
 
 ## Supported Email Providers
-- **Cloudflare Workers or Node.js**: SendGrid, Mailgun, and Brevo
+- **Cloudflare Workers or Node.js**: SendGrid, Mailgun, Resend.com and Brevo
 -	**Node.js (Only)**: SMTP server (in addition to the above)
 
 ## Environment Variables
@@ -18,7 +18,7 @@ Use the table below to configure your chosen email provider. Some variables are 
 | MAILGUN_SENDER_ADDRESS | Sender email address in Mailgun (Required if you intend to use Mailgun) | "noreply@yourdomain.com" |
 | BREVO_API_KEY | Your Brevo API key (Required if you intend to use Brevo) | "xkeysib-xxxxxxxxxxxxxxxxxxxxxxxx" |
 | BREVO_SENDER_ADDRESS | Verified sender address in Brevo (Required if you intend to use Brevo) | "noreply@yourdomain.com" |
-| RESEND_API_KEY | Your Resend.io API key (Required if you intend to use Resend.io) | "re_xxxxxxxxxxxxxxxxxxxxxxx" |
+| RESEND_API_KEY | Your Resend.com API key (Required if you intend to use Resend.com) | "re_xxxxxxxxxxxxxxxxxxxxxxx" |
 | RESEND_SENDER_ADDRESS | Verified sender address in Resend.com (Required if you intend to use Resend.com) |
 | SMTP_SENDER_ADDRESS | SMTP sender email address (Node.js only) | "noreply@yourdomain.com" |
 | SMTP_CONNECTION_STRING | SMTP connection string (Node.js only) | "smtp://username:password@smtp.mailserver.com:587" |

--- a/docs/email-provider-setup.md
+++ b/docs/email-provider-setup.md
@@ -34,12 +34,12 @@ Use the table below to configure your chosen email provider. Some variables are 
 
 ## Priority Between Providers
 - Node.js Environment
-  - If SMTP_CONNECTION_STRING is defined, SMTP will always be used—regardless of SendGrid, Mailgun, or Brevo settings.
-  - Otherwise, if more than one API key and sender address are provided (SendGrid, Mailgun, Brevo), SendGrid is used first, then Mailgun, and finally Brevo.
+  - If SMTP_CONNECTION_STRING is defined, SMTP will always be used—regardless of SendGrid, Mailgun, Brevo or Resend settings.
+  - Otherwise, if more than one API key and sender address are provided (SendGrid, Mailgun, Brevo, Resend), SendGrid is used first, then Mailgun, Brevo and finally Resend.
 
 - Cloudflare Environment
   - SMTP settings are ignored.
-  - If you set up multiple providers (SendGrid, Mailgun, Brevo), SendGrid takes priority, followed by Mailgun and then Brevo.
+  - If you set up multiple providers (SendGrid, Mailgun, Brevo), SendGrid takes priority, followed by Mailgun, Brevo and then Resend.
 
 ## Cloudflare Remote/Production Configuration
 1. Navigate to the Cloudflare dashboard -> Go to "Workers & Pages"

--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -14,7 +14,7 @@ DEV_SMS_RECEIVER= # When the ENVIRONMENT is not set to 'prod', all SMS messages 
 #MAILGUN_SENDER_ADDRESS= # Put your Mailgun sender address here
 #BREVO_API_KEY= # Put your Brevo api key here and leave both SENDGRID_API_KEY and MAILGUN_API_KEY to be empty if you want to use Brevo handle email functionalities
 #BREVO_SENDER_ADDRESS= # Put your Brevo sender address here
-#RESEND_API_KEY= # Put your Resend api key here and leave SENDGRID_API_KEY, MAILGUN, BREVO empty if you want to use Resend handle email functionalities
+#RESEND_API_KEY= # Put your Resend api key here and leave SENDGRID_API_KEY, MAILGUN_API_KEY, BREVO_API_KEY empty if you want to use Resend handle email functionalities
 #RESEND_SENDER_ADDRESS= # Put your Resend sender address here
 
 # Config following env vars to work with SMS MFA

--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -14,7 +14,8 @@ DEV_SMS_RECEIVER= # When the ENVIRONMENT is not set to 'prod', all SMS messages 
 #MAILGUN_SENDER_ADDRESS= # Put your Mailgun sender address here
 #BREVO_API_KEY= # Put your Brevo api key here and leave both SENDGRID_API_KEY and MAILGUN_API_KEY to be empty if you want to use Brevo handle email functionalities
 #BREVO_SENDER_ADDRESS= # Put your Brevo sender address here
-
+#RESEND_API_KEY= # Put your Resend api key here and leave SENDGRID_API_KEY, MAILGUN, BREVO empty if you want to use Resend handle email functionalities
+#RESEND_SENDER_ADDRESS= # Put your Resend sender address here
 
 # Config following env vars to work with SMS MFA
 #TWILIO_ACCOUNT_ID= # Put your Twilio account id here

--- a/server/src/__tests__/normal/identity-other.test.tsx
+++ b/server/src/__tests__/normal/identity-other.test.tsx
@@ -1,31 +1,31 @@
 import { Database } from 'better-sqlite3'
+import { JSDOM } from 'jsdom'
 import {
-    adapterConfig,
-    localeConfig,
-    routeConfig,
+  afterEach, beforeEach, describe, expect, Mock, test,
+  vi,
+} from 'vitest'
+import {
+  adapterConfig,
+  localeConfig,
+  routeConfig,
 } from 'configs'
 import app from 'index'
-import { JSDOM } from 'jsdom'
 import { userModel } from 'models'
 import {
-    getApp,
-    getAuthorizeParams,
-    insertUsers,
-    postAuthorizeBody,
-    postSignInRequest,
+  getApp,
+  getAuthorizeParams,
+  insertUsers,
+  postAuthorizeBody,
+  postSignInRequest,
 } from 'tests/identity'
 import {
-    emailLogRecord,
-    emailResponseMock,
-    fetchMock,
-    migrate, mock,
-    mockedKV,
+  emailLogRecord,
+  emailResponseMock,
+  fetchMock,
+  migrate, mock,
+  mockedKV,
 } from 'tests/mock'
 import { disableUser } from 'tests/util'
-import {
-    afterEach, beforeEach, describe, expect, Mock, test,
-    vi,
-} from 'vitest'
 
 let db: Database
 

--- a/server/src/__tests__/normal/user.test.tsx
+++ b/server/src/__tests__/normal/user.test.tsx
@@ -1,35 +1,35 @@
 import { Database } from 'better-sqlite3'
-import { Scope } from 'shared'
 import {
-  afterEach, beforeEach, describe, expect, Mock, test,
-  vi,
-} from 'vitest'
-import {
-  adapterConfig, localeConfig, routeConfig,
+    adapterConfig, localeConfig, routeConfig,
 } from 'configs'
 import app from 'index'
 import {
-  userAppConsentModel, userModel,
-  userPasskeyModel,
+    userAppConsentModel, userModel,
+    userPasskeyModel,
 } from 'models'
+import { Scope } from 'shared'
 import {
-  emailLogRecord,
-  emailResponseMock,
-  fetchMock,
-  migrate, mock,
-  mockedKV,
+    emailLogRecord,
+    emailResponseMock,
+    fetchMock,
+    migrate, mock,
+    mockedKV,
 } from 'tests/mock'
 import {
-  attachIndividualScopes,
-  dbTime, disableUser, enrollEmailMfa, enrollOtpMfa,
-  enrollSmsMfa,
-  getS2sToken,
+    attachIndividualScopes,
+    dbTime, disableUser, enrollEmailMfa, enrollOtpMfa,
+    enrollSmsMfa,
+    getS2sToken,
 } from 'tests/util'
+import {
+    afterEach, beforeEach, describe, expect, Mock, test,
+    vi,
+} from 'vitest'
 
 let db: Database
 
 const insertUsers = async () => {
-  await db.exec(`
+  db.exec(`
     INSERT INTO "user"
     ("authId", locale, email, "socialAccountId", "socialAccountType", password, "firstName", "lastName")
     values ('1-1-1-1', 'en', 'test@email.com', null, null, '$2a$10$3HtEAf8YcN94V4GOR6ZBNu9tmoIflmEOqb9hUf0iqS4OjYVKe.9/C', null, null)

--- a/server/src/__tests__/normal/user.test.tsx
+++ b/server/src/__tests__/normal/user.test.tsx
@@ -29,7 +29,7 @@ import {
 let db: Database
 
 const insertUsers = async () => {
-  db.exec(`
+  await db.exec(`
     INSERT INTO "user"
     ("authId", locale, email, "socialAccountId", "socialAccountType", password, "firstName", "lastName")
     values ('1-1-1-1', 'en', 'test@email.com', null, null, '$2a$10$3HtEAf8YcN94V4GOR6ZBNu9tmoIflmEOqb9hUf0iqS4OjYVKe.9/C', null, null)

--- a/server/src/__tests__/normal/user.test.tsx
+++ b/server/src/__tests__/normal/user.test.tsx
@@ -1,30 +1,30 @@
 import { Database } from 'better-sqlite3'
+import { Scope } from 'shared'
 import {
-    adapterConfig, localeConfig, routeConfig,
+  afterEach, beforeEach, describe, expect, Mock, test,
+  vi,
+} from 'vitest'
+import {
+  adapterConfig, localeConfig, routeConfig,
 } from 'configs'
 import app from 'index'
 import {
-    userAppConsentModel, userModel,
-    userPasskeyModel,
+  userAppConsentModel, userModel,
+  userPasskeyModel,
 } from 'models'
-import { Scope } from 'shared'
 import {
-    emailLogRecord,
-    emailResponseMock,
-    fetchMock,
-    migrate, mock,
-    mockedKV,
+  emailLogRecord,
+  emailResponseMock,
+  fetchMock,
+  migrate, mock,
+  mockedKV,
 } from 'tests/mock'
 import {
-    attachIndividualScopes,
-    dbTime, disableUser, enrollEmailMfa, enrollOtpMfa,
-    enrollSmsMfa,
-    getS2sToken,
+  attachIndividualScopes,
+  dbTime, disableUser, enrollEmailMfa, enrollOtpMfa,
+  enrollSmsMfa,
+  getS2sToken,
 } from 'tests/util'
-import {
-    afterEach, beforeEach, describe, expect, Mock, test,
-    vi,
-} from 'vitest'
 
 let db: Database
 

--- a/server/src/configs/type.ts
+++ b/server/src/configs/type.ts
@@ -23,6 +23,8 @@ export type Bindings = {
   BREVO_SENDER_ADDRESS: string;
   MAILGUN_API_KEY: string;
   MAILGUN_SENDER_ADDRESS: string;
+  RESEND_API_KEY: string;
+  RESEND_SENDER_ADDRESS: string;
   SMS_MFA_IS_REQUIRED: boolean;
   SMS_MFA_COUNTRY_CODE: string;
   SMS_MFA_MESSAGE_THRESHOLD: number;

--- a/server/src/services/email.tsx
+++ b/server/src/services/email.tsx
@@ -1,24 +1,25 @@
+import {
+    errorConfig,
+    localeConfig, typeConfig,
+} from 'configs'
 import { Context } from 'hono'
 import { env } from 'hono/adapter'
+import {
+    emailLogModel, userModel,
+} from 'models'
+import { brandingService } from 'services'
+import {
+    ChangeEmailVerificationTemplate,
+    EmailMfaTemplate,
+    EmailVerificationTemplate, PasswordResetTemplate,
+} from 'templates'
+import { cryptoUtil } from 'utils'
 import { BrevoMailer } from './email/brevo'
 import { IMailer } from './email/interface'
 import { MailgunMailer } from './email/mailgun'
+import { ResendMailer } from './email/resend'
 import { SendgridMailer } from './email/sendgrid'
 import { SmtpMailer } from './email/smtp'
-import { cryptoUtil } from 'utils'
-import {
-  ChangeEmailVerificationTemplate,
-  EmailMfaTemplate,
-  EmailVerificationTemplate, PasswordResetTemplate,
-} from 'templates'
-import { brandingService } from 'services'
-import {
-  emailLogModel, userModel,
-} from 'models'
-import {
-  errorConfig,
-  localeConfig, typeConfig,
-} from 'configs'
 
 const checkEmailSetup = (c: Context<typeConfig.Context>) => {
   const {
@@ -28,12 +29,15 @@ const checkEmailSetup = (c: Context<typeConfig.Context>) => {
     SENDGRID_SENDER_ADDRESS: sendgridSender,
     MAILGUN_API_KEY: mailgunApiKey,
     MAILGUN_SENDER_ADDRESS: mailgunSender,
+    RESEND_API_KEY: resendApiKey,
+    RESEND_SENDER_ADDRESS: resendSender,
   } = env(c)
   if (
     !c.env.SMTP &&
     (!mailgunApiKey || !mailgunSender) &&
     (!brevoApiKey || !brevoSender) &&
-    (!sendgridApiKey || !sendgridSender)
+    (!sendgridApiKey || !sendgridSender) &&
+    (!resendApiKey || !resendSender)
   ) {
     throw new errorConfig.Forbidden(localeConfig.Error.NoEmailSender)
   }
@@ -55,6 +59,10 @@ const buildMailer = (context: Context<typeConfig.Context>): IMailer | null => {
 
   if (vars.BREVO_API_KEY && vars.BREVO_SENDER_ADDRESS) {
     return new BrevoMailer({ context })
+  }
+
+  if (vars.RESEND_API_KEY && vars.RESEND_SENDER_ADDRESS) {
+    return new ResendMailer({ context })
   }
 
   return null

--- a/server/src/services/email.tsx
+++ b/server/src/services/email.tsx
@@ -1,25 +1,25 @@
-import {
-    errorConfig,
-    localeConfig, typeConfig,
-} from 'configs'
 import { Context } from 'hono'
 import { env } from 'hono/adapter'
-import {
-    emailLogModel, userModel,
-} from 'models'
-import { brandingService } from 'services'
-import {
-    ChangeEmailVerificationTemplate,
-    EmailMfaTemplate,
-    EmailVerificationTemplate, PasswordResetTemplate,
-} from 'templates'
-import { cryptoUtil } from 'utils'
 import { BrevoMailer } from './email/brevo'
 import { IMailer } from './email/interface'
 import { MailgunMailer } from './email/mailgun'
 import { ResendMailer } from './email/resend'
 import { SendgridMailer } from './email/sendgrid'
 import { SmtpMailer } from './email/smtp'
+import { cryptoUtil } from 'utils'
+import {
+  ChangeEmailVerificationTemplate,
+  EmailMfaTemplate,
+  EmailVerificationTemplate, PasswordResetTemplate,
+} from 'templates'
+import { brandingService } from 'services'
+import {
+  emailLogModel, userModel,
+} from 'models'
+import {
+  errorConfig,
+  localeConfig, typeConfig,
+} from 'configs'
 
 const checkEmailSetup = (c: Context<typeConfig.Context>) => {
   const {

--- a/server/src/services/email/resend.ts
+++ b/server/src/services/email/resend.ts
@@ -26,7 +26,7 @@ export class ResendMailer extends IMailer {
           subject,
           html: content,
           to: [email],
-          from: `${senderName} <${senderEmail}>`
+          from: `${senderName} <${senderEmail}>`,
         }),
       },
     )

--- a/server/src/services/email/resend.ts
+++ b/server/src/services/email/resend.ts
@@ -1,0 +1,36 @@
+import { env } from 'hono/adapter'
+import {
+  IMailer, SendEmailOptions,
+} from './interface'
+
+/**
+* @docs https://resend.com/docs/api-reference/emails/send-email
+*/
+export class ResendMailer extends IMailer {
+  async sendEmail ({
+    email, subject, content, senderName,
+  }: SendEmailOptions) {
+    const {
+      RESEND_API_KEY: apiKey, RESEND_SENDER_ADDRESS: senderEmail,
+    } = env(this.context)
+
+    const res = await fetch(
+      'https://api.resend.com/emails',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          subject,
+          html: content,
+          to: [email],
+          from: `${senderName} <${senderEmail}>`
+        }),
+      },
+    )
+
+    return res
+  }
+}


### PR DESCRIPTION
Hello 👋🏽 

As mentioned on #236, this PR adds support to use https://resend.com as one of the email providers.

Users will need to follow the required setup to enable it (e.g. adding their domains to resend and so on)

Tested with `ENVIRONMENT = 'prod'`

This PR:

- Adds the `ResendMailer`
- Adds the current test coverage to resend as well
- Updated docs

<img width="736" alt="Screenshot 2025-02-23 at 00 23 53" src="https://github.com/user-attachments/assets/8aeace83-774d-4a2b-a89c-617ab5e5fd7b" />
