### PR TITLE
fix admin panel build warning on i18.ts

### DIFF
--- a/admin-panel/i18n.ts
+++ b/admin-panel/i18n.ts
@@ -3,8 +3,12 @@ import { getRequestConfig } from 'next-intl/server'
 
 const locales = ['en', 'fr']
 
-export default getRequestConfig(async ({ locale }: { locale:string}) => {
+export default getRequestConfig(async ({ requestLocale }) => {
+  const locale = await requestLocale || 'en'
   if (!locales.includes(locale)) notFound()
 
-  return { messages: (await import(`./translations/${locale}.json`)).default }
+  return {
+    locale,
+    messages: (await import(`./translations/${locale}.json`)).default,
+  }
 })


### PR DESCRIPTION
`npm run cf:build` with a clean repo gives a warning during the build:

```
[next-intl] Reading request configuration from ./i18n.ts is deprecated, please see https://next-intl.dev/blog/next-intl-3-22#i18n-request — you can either move your configuration to ./i18n/request.ts or provide a custom path in your Next.js config:

const withNextIntl = createNextIntlPlugin(
  './path/to/i18n/request.tsx'
);
```
As we are only pulling the locale, this patch fixes that and removes the deprecation warning.